### PR TITLE
fix: add conditional to check if response is 'Unauthorized'

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,6 +93,10 @@ func parse_pod(target string) *RunningPods {
     log.Fatalln(string(body))
   }
 
+  if strings.HasPrefix(string(body), "Forbidden") {
+    log.Fatalln(string(body))
+  }
+
 	pods := &RunningPods{}
 
 	err = json.Unmarshal(body, &pods)

--- a/main.go
+++ b/main.go
@@ -89,6 +89,10 @@ func parse_pod(target string) *RunningPods {
 		fmt.Print("Fail to read body")
 	}
 
+  if string(body) == "Unauthorized" {
+    log.Fatalln(string(body))
+  }
+
 	pods := &RunningPods{}
 
 	err = json.Unmarshal(body, &pods)


### PR DESCRIPTION
Issue: #1 

* Check if response is "Unauthorized" and exit - showing response to User (= no `anonymous` access on kubelet allowed)
* Check if response starts with "Forbidden" and exit - showing response to User (= unsufficient RBAC for `anonymous` user)